### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!,except:[:index,:show] 
   before_action :choose_item,only:[:show,:edit,:update]
-  before_action :correct_edit,only:[:edit,:update]
+  before_action :correct_edit,only:[:edit,:update,:destroy]
 
   def index
     @items = Item.includes(:user).order("id DESC")

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,6 +34,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
   private
   def item_params
     params.require(:item).permit(:image,:name,:detail,:category_id,:condition_id,:delivery_charge_id,:prefecture_id,:delivery_time_id,:price).merge(user_id:current_user.id)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if current_user.id == @item.user.id %>
         <%= link_to "商品の編集", edit_item_path(@item.id) , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
         <%# 商品が売れていない場合はこちらを表示しましょう ！！！あとで実装します！！！%>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
# what
商品削除機能の実装

# why
ユーザーが自身の商品を自身で削除したいときに有効であるため

【動画】

[ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画](https://gyazo.com/bbd3c4e6936982f57997b2cc999ccb1b)